### PR TITLE
Add attributes search option

### DIFF
--- a/search.go
+++ b/search.go
@@ -12,6 +12,7 @@ import (
 
 type SearchJob struct {
 	BaseJob
+	attributes  []string
 	baseDN  string
 	scope   int
 	filter  string
@@ -30,6 +31,11 @@ var searchFlags = []cli.Flag{
 		Name:  "a, filter",
 		Value: "(objectClass=*)",
 		Usage: "filter",
+	},
+	&cli.StringFlag{
+		Name:  "attributes",
+		Value: "dn",
+		Usage: "space-separated list of attributes as a single string",
 	},
 	&cli.IntFlag{
 		Name:  "first",
@@ -59,6 +65,7 @@ func (job *SearchJob) Prep(c *cli.Context) bool {
 	}
 	job.baseDN = c.String("b")
 	job.filter = c.String("a")
+	job.attributes = strings.Fields(c.String("t"))
 	job.first = c.Int("first")
 	job.last = c.Int("last")
 	switch c.String("s") {
@@ -93,7 +100,7 @@ func (job *SearchJob) Request() bool {
 		Scope:        job.scope,
 		DerefAliases: 0,
 		Filter:       filter,
-		Attributes:   []string{"dn"},
+		Attributes:   job.attributes,
 	}
 	res, err := job.conn.Search(&req)
 	if err != nil {


### PR DESCRIPTION
Add attributes search option

```
NAME:
   lb search - LDAP SEARCH Benchmarking

USAGE:
   lb search [command options] [arguments...]

OPTIONS:
   --verbose value     How much troubleshooting info to print (default: 0)
   --quiet             Quiet flag (default: false)
   -n value            Number of requests to perform (default: 1)
   -c value            Number of multiple requests to make (default: 1)
   -D value            Bind DN (default: "cn=Manager,dc=example,dc=com")
   -w value            Bind Secret (default: "secret")
   -b value            BaseDN (default: "dc=example,dc=com")
   --starttls          Use StartTLS (default: false)
   --short             short result (default: false)
   -s value            scope (default: "sub")
   -a value            filter (default: "(objectClass=*)")
   --attributes value  space-separated list of attributes as a single string (default: "dn")
   --first value       first id (default: 1)
   --last value        last id (default: 0)
   --help, -h          show help (default: false)
```

```
search -c 5 -n 1 -D dc=example,dc=org -w secret -b dc=example,dc=org -a "(&(cn=*)(uidNumber=*))" --attributes '* modifyTimestamp' ldaps://localhost:1636
```

